### PR TITLE
feat: optional portions field for recipes

### DIFF
--- a/drizzle/0011_RecipePortions.sql
+++ b/drizzle/0011_RecipePortions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "recipes" ADD COLUMN "portions" integer;

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,373 @@
+{
+  "id": "c68442d1-a277-435a-a1b8-d075e359e1db",
+  "prevId": "f2cffbef-0815-4306-a7c1-8b7f3be6dd2f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ingredients": {
+      "name": "ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingredients_recipe_id_idx": {
+          "name": "ingredients_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingredients_recipe_id_recipes_id_fk": {
+          "name": "ingredients_recipe_id_recipes_id_fk",
+          "tableFrom": "ingredients",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instructions": {
+      "name": "instructions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "instructions_recipe_id_idx": {
+          "name": "instructions_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instructions_recipe_id_recipes_id_fk": {
+          "name": "instructions_recipe_id_recipes_id_fk",
+          "tableFrom": "instructions",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portions": {
+          "name": "portions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipes_slug_unique": {
+          "name": "recipes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipes_to_tags": {
+      "name": "recipes_to_tags",
+      "schema": "",
+      "columns": {
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "recipes_to_tags_tag_id_idx": {
+          "name": "recipes_to_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipes_to_tags_recipe_id_recipes_id_fk": {
+          "name": "recipes_to_tags_recipe_id_recipes_id_fk",
+          "tableFrom": "recipes_to_tags",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipes_to_tags_tag_id_tags_id_fk": {
+          "name": "recipes_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "recipes_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "recipes_to_tags_recipe_id_tag_id_pk": {
+          "name": "recipes_to_tags_recipe_id_tag_id_pk",
+          "columns": [
+            "recipe_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "tag_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_slug_idx": {
+          "name": "tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_slug_category_unique": {
+          "name": "tags_slug_category_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug",
+            "category"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.tag_category": {
+      "name": "tag_category",
+      "schema": "public",
+      "values": [
+        "type",
+        "cuisine",
+        "nutrition",
+        "diet"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778880947984,
       "tag": "0010_RecipeDuration",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1778934417842,
+      "tag": "0011_RecipePortions",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/api/recipes.remote.ts
+++ b/src/lib/api/recipes.remote.ts
@@ -134,7 +134,8 @@ export const updateRecipeDetails = form(
 		tagNutrition: z.array(z.string()).optional().default([]),
 		tagDiet: z.array(z.string()).optional().default([]),
 		imageUrl: z.string().optional(),
-		durationMinutes: z.number().int().nonnegative().optional()
+		durationMinutes: z.number().int().nonnegative().optional(),
+		portions: z.number().int().min(1).max(99).optional()
 	}),
 	async ({
 		recipeId,
@@ -145,7 +146,8 @@ export const updateRecipeDetails = form(
 		tagNutrition,
 		tagDiet,
 		imageUrl,
-		durationMinutes
+		durationMinutes,
+		portions
 	}) => {
 		if (!userCanWrite()) {
 			throwNewPermissionError();
@@ -166,6 +168,7 @@ export const updateRecipeDetails = form(
 			description,
 			imageUrl,
 			durationMinutes: durationMinutes ?? null,
+			portions: portions ?? null,
 			tags
 		});
 
@@ -186,7 +189,8 @@ export const createRecipe = form(
 		tagDiet: z.array(z.string()).optional().default([]),
 		imageUrl: z.string().optional(),
 		importImage: z.instanceof(File).optional(),
-		durationMinutes: z.number().int().nonnegative().optional()
+		durationMinutes: z.number().int().nonnegative().optional(),
+		portions: z.number().int().min(1).max(99).optional()
 	}),
 	async ({
 		name,
@@ -197,7 +201,8 @@ export const createRecipe = form(
 		tagDiet,
 		imageUrl,
 		importImage,
-		durationMinutes
+		durationMinutes,
+		portions
 	}) => {
 		if (!userCanWrite()) {
 			throwNewPermissionError();
@@ -220,6 +225,7 @@ export const createRecipe = form(
 			description: description.trim(),
 			imageUrl,
 			durationMinutes: durationMinutes ?? null,
+			portions: portions ?? null,
 			ingredients: extracted.ingredients,
 			instructions: extracted.instructions.map((item, i) => ({ ...item, stepOrder: i + 1 })),
 			tags

--- a/src/lib/api/recipes.remote.ts
+++ b/src/lib/api/recipes.remote.ts
@@ -134,8 +134,7 @@ export const updateRecipeDetails = form(
 		tagNutrition: z.array(z.string()).optional().default([]),
 		tagDiet: z.array(z.string()).optional().default([]),
 		imageUrl: z.string().optional(),
-		durationMinutes: z.number().int().nonnegative().optional(),
-		portions: z.number().int().min(1).max(99).optional()
+		durationMinutes: z.number().int().nonnegative().optional()
 	}),
 	async ({
 		recipeId,
@@ -146,8 +145,7 @@ export const updateRecipeDetails = form(
 		tagNutrition,
 		tagDiet,
 		imageUrl,
-		durationMinutes,
-		portions
+		durationMinutes
 	}) => {
 		if (!userCanWrite()) {
 			throwNewPermissionError();
@@ -168,7 +166,6 @@ export const updateRecipeDetails = form(
 			description,
 			imageUrl,
 			durationMinutes: durationMinutes ?? null,
-			portions: portions ?? null,
 			tags
 		});
 
@@ -189,8 +186,7 @@ export const createRecipe = form(
 		tagDiet: z.array(z.string()).optional().default([]),
 		imageUrl: z.string().optional(),
 		importImage: z.instanceof(File).optional(),
-		durationMinutes: z.number().int().nonnegative().optional(),
-		portions: z.number().int().min(1).max(99).optional()
+		durationMinutes: z.number().int().nonnegative().optional()
 	}),
 	async ({
 		name,
@@ -201,8 +197,7 @@ export const createRecipe = form(
 		tagDiet,
 		imageUrl,
 		importImage,
-		durationMinutes,
-		portions
+		durationMinutes
 	}) => {
 		if (!userCanWrite()) {
 			throwNewPermissionError();
@@ -225,7 +220,6 @@ export const createRecipe = form(
 			description: description.trim(),
 			imageUrl,
 			durationMinutes: durationMinutes ?? null,
-			portions: portions ?? null,
 			ingredients: extracted.ingredients,
 			instructions: extracted.instructions.map((item, i) => ({ ...item, stepOrder: i + 1 })),
 			tags
@@ -291,6 +285,22 @@ export const uploadRecipeImage = form(
 		await getRecipeBySlug(result.slug).refresh();
 
 		return { url };
+	}
+);
+
+export const updateRecipePortions = command(
+	z.object({
+		recipeId: z.number(),
+		portions: z.number().int().min(1).max(99).nullable()
+	}),
+	async ({ recipeId, portions }) => {
+		if (!userCanWrite()) {
+			throwNewPermissionError();
+		}
+
+		const recipe = await recipeService.getRecipeById(recipeId);
+		await recipeService.updateRecipe(recipeId, { portions });
+		await getRecipeBySlug(recipe.slug).refresh();
 	}
 );
 

--- a/src/lib/components/ingredients/IngredientsSheet.svelte
+++ b/src/lib/components/ingredients/IngredientsSheet.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { addIngredient, getRecipeBySlug } from '$lib/api/recipes.remote';
+	import { addIngredient, getRecipeBySlug, updateRecipePortions } from '$lib/api/recipes.remote';
 	import { Button, buttonVariants } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import NumberStepper from '$lib/components/ui/NumberStepper.svelte';
 	import { Separator } from '$lib/components/ui/separator';
 	import * as Sheet from '$lib/components/ui/sheet/';
 	import type { Ingredient } from '$lib/server/types';
@@ -12,8 +13,18 @@
 	const {
 		recipeId,
 		recipeSlug,
-		ingredients
-	}: { recipeId: number; recipeSlug: string; ingredients: Ingredient[] } = $props();
+		ingredients,
+		portions
+	}: {
+		recipeId: number;
+		recipeSlug: string;
+		ingredients: Ingredient[];
+		portions: number | null;
+	} = $props();
+
+	async function handlePortionsChange(value: number | null) {
+		await updateRecipePortions({ recipeId, portions: value });
+	}
 
 	let inputRef = $state<HTMLInputElement | null>(null);
 	let editingId = $state<number | null>(null);
@@ -27,6 +38,14 @@
 		<Sheet.Header>
 			<Sheet.Title>Edit Ingredients</Sheet.Title>
 			<Sheet.Description>Make changes to the ingredients for this recipe.</Sheet.Description>
+			<div class="mt-4">
+				<NumberStepper
+					label="Portions"
+					value={portions}
+					onchange={handlePortionsChange}
+					placeholder="—"
+				/>
+			</div>
 			<form
 				{...addIngredient.enhance(async ({ form, data, submit }) => {
 					try {

--- a/src/lib/components/recipes/CategoryTagInputComponent.svelte
+++ b/src/lib/components/recipes/CategoryTagInputComponent.svelte
@@ -6,12 +6,14 @@
 		typeTags = $bindable([]),
 		cuisineTags = $bindable([]),
 		nutritionTags = $bindable([]),
-		dietTags = $bindable([])
+		dietTags = $bindable([]),
+		class: className
 	}: {
 		typeTags?: string[];
 		cuisineTags?: string[];
 		nutritionTags?: string[];
 		dietTags?: string[];
+		class?: string;
 	} = $props();
 
 	const PLACEHOLDERS: Record<TagCategory, string> = {
@@ -22,7 +24,7 @@
 	};
 </script>
 
-<div class="flex flex-col gap-4">
+<div class="flex flex-col gap-4 {className}">
 	<TagInputComponent
 		label="Type"
 		placeholder={PLACEHOLDERS.type}

--- a/src/lib/components/recipes/RecipeDetailsFormComponent.svelte
+++ b/src/lib/components/recipes/RecipeDetailsFormComponent.svelte
@@ -3,6 +3,7 @@
 	import SingleSelectComponent from '$lib/components/common/SingleSelectComponent.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import NumberStepper from '$lib/components/ui/NumberStepper.svelte';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import type { RecipeWithDetails, TagCategory } from '$lib/server/types';
 	import { DURATION_BUCKETS, formatDuration } from '$lib/shared/duration';
@@ -26,6 +27,7 @@
 	let nutritionTags = $state(getTagsByCategory('nutrition'));
 	let dietTags = $state(getTagsByCategory('diet'));
 	let durationMinutes = $state<number | null>(untrack(() => recipe.durationMinutes));
+	let portions = $state<number | null>(untrack(() => recipe.portions));
 
 	const durationOptions = DURATION_BUCKETS.map((min) => ({
 		value: min,
@@ -57,12 +59,18 @@
 		value={recipe.description}
 		required
 	/>
-	<div class="flex flex-row flex-wrap gap-2">
+	<div class="flex flex-row flex-wrap items-center gap-4">
 		<SingleSelectComponent
 			label="Duration"
 			options={durationOptions}
 			value={durationMinutes}
 			onchange={(v) => (durationMinutes = v)}
+		/>
+		<NumberStepper
+			label="Portions"
+			value={portions}
+			onchange={(v) => (portions = v)}
+			placeholder="—"
 		/>
 	</div>
 	{#if durationMinutes != null}
@@ -71,7 +79,16 @@
 			class="hidden"
 		/>
 	{/if}
-	<CategoryTagInputComponent bind:typeTags bind:cuisineTags bind:nutritionTags bind:dietTags />
+	{#if portions != null}
+		<input {...updateRecipeDetails.fields.portions.as('number', portions)} class="hidden" />
+	{/if}
+	<CategoryTagInputComponent
+		bind:typeTags
+		bind:cuisineTags
+		bind:nutritionTags
+		bind:dietTags
+		class="mt-4"
+	/>
 	{#each typeTags as tag, i (tag)}
 		<input {...updateRecipeDetails.fields.tagType[i].as('hidden', tag)} />
 	{/each}

--- a/src/lib/components/recipes/RecipeDetailsFormComponent.svelte
+++ b/src/lib/components/recipes/RecipeDetailsFormComponent.svelte
@@ -3,7 +3,6 @@
 	import SingleSelectComponent from '$lib/components/common/SingleSelectComponent.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import NumberStepper from '$lib/components/ui/NumberStepper.svelte';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import type { RecipeWithDetails, TagCategory } from '$lib/server/types';
 	import { DURATION_BUCKETS, formatDuration } from '$lib/shared/duration';
@@ -27,7 +26,6 @@
 	let nutritionTags = $state(getTagsByCategory('nutrition'));
 	let dietTags = $state(getTagsByCategory('diet'));
 	let durationMinutes = $state<number | null>(untrack(() => recipe.durationMinutes));
-	let portions = $state<number | null>(untrack(() => recipe.portions));
 
 	const durationOptions = DURATION_BUCKETS.map((min) => ({
 		value: min,
@@ -59,18 +57,12 @@
 		value={recipe.description}
 		required
 	/>
-	<div class="flex flex-row flex-wrap items-center gap-4">
+	<div class="flex flex-row flex-wrap gap-2">
 		<SingleSelectComponent
 			label="Duration"
 			options={durationOptions}
 			value={durationMinutes}
 			onchange={(v) => (durationMinutes = v)}
-		/>
-		<NumberStepper
-			label="Portions"
-			value={portions}
-			onchange={(v) => (portions = v)}
-			placeholder="—"
 		/>
 	</div>
 	{#if durationMinutes != null}
@@ -78,9 +70,6 @@
 			{...updateRecipeDetails.fields.durationMinutes.as('number', durationMinutes)}
 			class="hidden"
 		/>
-	{/if}
-	{#if portions != null}
-		<input {...updateRecipeDetails.fields.portions.as('number', portions)} class="hidden" />
 	{/if}
 	<CategoryTagInputComponent
 		bind:typeTags

--- a/src/lib/components/ui/NumberStepper.svelte
+++ b/src/lib/components/ui/NumberStepper.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/';
+	import { Input } from '$lib/components/ui/input/';
+	import MinusIcon from '@lucide/svelte/icons/minus';
+	import PlusIcon from '@lucide/svelte/icons/plus';
+
+	let {
+		value,
+		onchange,
+		min = 1,
+		max = 99,
+		label,
+		placeholder,
+		id
+	}: {
+		value: number | null;
+		onchange: (value: number | null) => void;
+		min?: number;
+		max?: number;
+		label?: string;
+		placeholder?: string;
+		id?: string;
+	} = $props();
+
+	function clamp(n: number) {
+		return Math.min(max, Math.max(min, n));
+	}
+
+	function decrement() {
+		if (value == null) return;
+		const next = value - 1;
+		onchange(next < min ? null : clamp(next));
+	}
+
+	function increment() {
+		if (value == null) {
+			onchange(min);
+			return;
+		}
+		if (value >= max) return;
+		onchange(clamp(value + 1));
+	}
+
+	function handleInput(e: Event) {
+		const target = e.currentTarget as HTMLInputElement;
+		const raw = target.value;
+		if (raw === '') {
+			onchange(null);
+			return;
+		}
+		const parsed = Number(raw);
+		if (!Number.isFinite(parsed)) return;
+		onchange(clamp(Math.trunc(parsed)));
+	}
+</script>
+
+<div class="inline-flex items-center gap-2">
+	{#if label}
+		<span class="text-sm">{label}</span>
+	{/if}
+	<div class="inline-flex items-center gap-1">
+		<Button
+			type="button"
+			variant="outline"
+			size="icon"
+			onclick={decrement}
+			disabled={value == null || value <= min}
+			aria-label="Decrease"
+		>
+			<MinusIcon />
+		</Button>
+		<Input
+			{id}
+			type="text"
+			inputmode="numeric"
+			pattern="[0-9]*"
+			{placeholder}
+			value={value ?? ''}
+			oninput={handleInput}
+			class="w-16 text-center"
+		/>
+		<Button
+			type="button"
+			variant="outline"
+			size="icon"
+			onclick={increment}
+			disabled={value != null && value >= max}
+			aria-label="Increase"
+		>
+			<PlusIcon />
+		</Button>
+	</div>
+</div>

--- a/src/lib/components/ui/NumberStepper.svelte.spec.ts
+++ b/src/lib/components/ui/NumberStepper.svelte.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+import NumberStepper from './NumberStepper.svelte';
+
+describe('NumberStepper.svelte', () => {
+	describe('rendering', () => {
+		it('should render label when provided', async () => {
+			render(NumberStepper, { value: null, onchange: vi.fn(), label: 'Portions' });
+			await expect.element(page.getByText('Portions')).toBeInTheDocument();
+		});
+
+		it('should render empty input when value is null', async () => {
+			render(NumberStepper, { value: null, onchange: vi.fn() });
+			const input = page.getByRole('textbox');
+			await expect.element(input).toHaveValue('');
+		});
+
+		it('should render value in input', async () => {
+			render(NumberStepper, { value: 4, onchange: vi.fn() });
+			const input = page.getByRole('textbox');
+			await expect.element(input).toHaveValue('4');
+		});
+	});
+
+	describe('increment', () => {
+		it('should start at min when incremented from empty', async () => {
+			const onchange = vi.fn();
+			render(NumberStepper, { value: null, onchange, min: 1 });
+			await page.getByLabelText('Increase').click();
+			expect(onchange).toHaveBeenCalledWith(1);
+		});
+
+		it('should increment current value by 1', async () => {
+			const onchange = vi.fn();
+			render(NumberStepper, { value: 3, onchange });
+			await page.getByLabelText('Increase').click();
+			expect(onchange).toHaveBeenCalledWith(4);
+		});
+
+		it('should disable plus button at max', async () => {
+			render(NumberStepper, { value: 99, onchange: vi.fn(), max: 99 });
+			await expect.element(page.getByLabelText('Increase')).toBeDisabled();
+		});
+	});
+
+	describe('decrement', () => {
+		it('should decrement current value by 1', async () => {
+			const onchange = vi.fn();
+			render(NumberStepper, { value: 4, onchange });
+			await page.getByLabelText('Decrease').click();
+			expect(onchange).toHaveBeenCalledWith(3);
+		});
+
+		it('should disable minus button at min', async () => {
+			render(NumberStepper, { value: 1, onchange: vi.fn(), min: 1 });
+			await expect.element(page.getByLabelText('Decrease')).toBeDisabled();
+		});
+
+		it('should disable minus button when null', async () => {
+			render(NumberStepper, { value: null, onchange: vi.fn() });
+			await expect.element(page.getByLabelText('Decrease')).toBeDisabled();
+		});
+	});
+});

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -20,6 +20,7 @@ export const recipes = pgTable('recipes', {
 	description: text('description'),
 	imageUrl: text('image_url'),
 	durationMinutes: integer('duration_minutes'),
+	portions: integer('portions'),
 	createdAt: timestamp('created_at').defaultNow()
 });
 

--- a/src/lib/server/services/recipe.service.ts
+++ b/src/lib/server/services/recipe.service.ts
@@ -125,8 +125,7 @@ export const createRecipe = async (
 				slug,
 				description: data.description,
 				imageUrl: data.imageUrl,
-				durationMinutes: data.durationMinutes,
-				portions: data.portions
+				durationMinutes: data.durationMinutes
 			})
 			.returning();
 

--- a/src/lib/server/services/recipe.service.ts
+++ b/src/lib/server/services/recipe.service.ts
@@ -125,7 +125,8 @@ export const createRecipe = async (
 				slug,
 				description: data.description,
 				imageUrl: data.imageUrl,
-				durationMinutes: data.durationMinutes
+				durationMinutes: data.durationMinutes,
+				portions: data.portions
 			})
 			.returning();
 
@@ -192,7 +193,8 @@ export const updateRecipe = async (
 				slug,
 				description: data.description,
 				imageUrl: data.imageUrl,
-				durationMinutes: data.durationMinutes
+				durationMinutes: data.durationMinutes,
+				portions: data.portions
 			})
 			.where(eq(recipes.id, id))
 			.returning();

--- a/src/routes/(app)/[slug]/+page.svelte
+++ b/src/routes/(app)/[slug]/+page.svelte
@@ -82,6 +82,9 @@
 						/>
 					{/if}
 				</div>
+				{#if recipe.portions != null}
+					<p class="pb-2 text-sm text-zinc-500">for {recipe.portions} portions</p>
+				{/if}
 				<IngredientsListComponent ingredients={recipe.ingredients} />
 			</div>
 			<div>
@@ -128,6 +131,9 @@
 					/>
 				{/if}
 			</div>
+			{#if recipe.portions != null}
+				<p class="pb-2 text-sm text-zinc-500">for {recipe.portions} portions</p>
+			{/if}
 			<IngredientsListComponent ingredients={recipe.ingredients} />
 		</div>
 	</div>

--- a/src/routes/(app)/[slug]/+page.svelte
+++ b/src/routes/(app)/[slug]/+page.svelte
@@ -79,6 +79,7 @@
 							ingredients={recipe.ingredients}
 							recipeId={recipe.id}
 							recipeSlug={recipe.slug}
+							portions={recipe.portions}
 						/>
 					{/if}
 				</div>
@@ -128,6 +129,7 @@
 						ingredients={recipe.ingredients}
 						recipeId={recipe.id}
 						recipeSlug={recipe.slug}
+						portions={recipe.portions}
 					/>
 				{/if}
 			</div>

--- a/src/routes/(app)/create/+page.svelte
+++ b/src/routes/(app)/create/+page.svelte
@@ -6,7 +6,6 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import NumberStepper from '$lib/components/ui/NumberStepper.svelte';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { DURATION_BUCKETS, formatDuration } from '$lib/shared/duration';
 	import type { PageData } from './$types';
@@ -18,7 +17,6 @@
 	let nutritionTags = $state<string[]>([]);
 	let dietTags = $state<string[]>([]);
 	let durationMinutes = $state<number | null>(null);
-	let portions = $state<number | null>(null);
 	let importImageName = $state<string | null>(null);
 	let importImageInput = $state<HTMLInputElement | null>(null);
 
@@ -48,25 +46,16 @@
 			{...createRecipe.fields.description.as('text')}
 		/>
 	</div>
-	<div class="flex flex-row flex-wrap items-center gap-4">
+	<div class="flex flex-row flex-wrap gap-2">
 		<SingleSelectComponent
 			label="Duration"
 			options={durationOptions}
 			value={durationMinutes}
 			onchange={(v) => (durationMinutes = v)}
 		/>
-		<NumberStepper
-			label="Portions"
-			value={portions}
-			onchange={(v) => (portions = v)}
-			placeholder="—"
-		/>
 	</div>
 	{#if durationMinutes != null}
 		<input {...createRecipe.fields.durationMinutes.as('number', durationMinutes)} class="hidden" />
-	{/if}
-	{#if portions != null}
-		<input {...createRecipe.fields.portions.as('number', portions)} class="hidden" />
 	{/if}
 	<CategoryTagInputComponent bind:typeTags bind:cuisineTags bind:nutritionTags bind:dietTags />
 	{#each typeTags as tag, i (tag)}

--- a/src/routes/(app)/create/+page.svelte
+++ b/src/routes/(app)/create/+page.svelte
@@ -6,6 +6,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import NumberStepper from '$lib/components/ui/NumberStepper.svelte';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { DURATION_BUCKETS, formatDuration } from '$lib/shared/duration';
 	import type { PageData } from './$types';
@@ -17,6 +18,7 @@
 	let nutritionTags = $state<string[]>([]);
 	let dietTags = $state<string[]>([]);
 	let durationMinutes = $state<number | null>(null);
+	let portions = $state<number | null>(null);
 	let importImageName = $state<string | null>(null);
 	let importImageInput = $state<HTMLInputElement | null>(null);
 
@@ -46,16 +48,25 @@
 			{...createRecipe.fields.description.as('text')}
 		/>
 	</div>
-	<div class="flex flex-row flex-wrap gap-2">
+	<div class="flex flex-row flex-wrap items-center gap-4">
 		<SingleSelectComponent
 			label="Duration"
 			options={durationOptions}
 			value={durationMinutes}
 			onchange={(v) => (durationMinutes = v)}
 		/>
+		<NumberStepper
+			label="Portions"
+			value={portions}
+			onchange={(v) => (portions = v)}
+			placeholder="—"
+		/>
 	</div>
 	{#if durationMinutes != null}
 		<input {...createRecipe.fields.durationMinutes.as('number', durationMinutes)} class="hidden" />
+	{/if}
+	{#if portions != null}
+		<input {...createRecipe.fields.portions.as('number', portions)} class="hidden" />
 	{/if}
 	<CategoryTagInputComponent bind:typeTags bind:cuisineTags bind:nutritionTags bind:dietTags />
 	{#each typeTags as tag, i (tag)}


### PR DESCRIPTION
## Summary
- Add nullable `portions` integer column to recipes (1-99, drizzle migration `0011_RecipePortions.sql`).
- New reusable `NumberStepper` UI component (text input + minus/plus buttons, no native spinners).
- Edit portions inside `IngredientsSheet` via dedicated `updateRecipePortions` command — auto-saves on each click.
- Render `for {n} portions` subtitle below the Ingredients heading on the recipe detail page (mobile + desktop), hidden when null.

Closes #137.

## Test plan
- [ ] Open a recipe → tap the edit-ingredients pen → stepper appears, sets/changes/clears portions, subtitle updates.
- [ ] Clear portions (decrement to empty) → subtitle disappears.
- [ ] Bounds: `+` from empty seeds at 1, `+` disabled at 99, `-` disabled at 1 and when empty.
- [ ] Create a fresh recipe — no portions field on the create form (intentional).
- [ ] `pnpm check`, `pnpm lint`, `pnpm test` all green.