### PR TITLE
feat: add label text to image upload area

### DIFF
--- a/src/routes/(app)/[slug]/+page.svelte
+++ b/src/routes/(app)/[slug]/+page.svelte
@@ -207,7 +207,10 @@
 				{#if !!uploadRecipeImage.pending}
 					<LoadingComponent />
 				{:else}
-					<PlusIcon class="size-8 text-zinc-500" />
+					<div class="flex flex-col items-center gap-1">
+						<PlusIcon class="size-8 text-zinc-500" />
+						<span class="text-sm text-zinc-500">Add image</span>
+					</div>
 				{/if}
 			</button>
 			<form {...uploadRecipeImage} enctype="multipart/form-data" class="hidden">


### PR DESCRIPTION
## Summary
- Adds "Add image" label below the plus icon in the empty-state image upload button on the recipe detail page
- Keeps styling consistent with existing icon (`text-sm text-zinc-500`)

## Test plan
- [ ] Open a recipe with no image as an editor
- [ ] Verify upload button shows plus icon + "Add image" label
- [ ] Verify upload still works after clicking

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)