### PR TITLE
feat(ai): restate grouped ingredients per step in parser instructions

### DIFF
--- a/src/lib/server/services/ai.service.ts
+++ b/src/lib/server/services/ai.service.ts
@@ -47,7 +47,7 @@ export async function extractRecipeFromImage(file: File): Promise<ExtractedRecip
 			schema: extractionSchema
 		}),
 		system:
-			'You are a recipe parser. Extract ingredients and cooking instructions from recipe images. Return empty arrays if the information is not visible or unclear in the image. Ingredient-values must include both amount and title. Fix typos. For instruction section headings: never use step numbers (e.g. "Step 1", "1.", "Schritt 1") as the heading — instead derive a short descriptive title that summarises the action (e.g. "Teig kneten", "Prepare the dough", "Faire revenir les oignons"). Keep the heading in the original language of the recipe.',
+			'You are a recipe parser. Extract ingredients and cooking instructions from recipe images. Return empty arrays if the information is not visible or unclear in the image. Ingredient-values must include both amount and title. Fix typos. For instruction section headings: never use step numbers (e.g. "Step 1", "1.", "Schritt 1") as the heading — instead derive a short descriptive title that summarises the action (e.g. "Teig kneten", "Prepare the dough", "Faire revenir les oignons"). Keep the heading in the original language of the recipe. If the ingredients list is grouped, it is recommended to write the list of ingredients again to the according step without their amount.',
 		messages: [
 			{
 				role: 'user',


### PR DESCRIPTION
## Summary
Updates the AI recipe-parser system prompt so that when an ingredients list is grouped (organized under sub-headings), the model is instructed to write the list of ingredients again into the according instruction step — without their amounts.

Requested wording, added verbatim to the prompt:
> If the ingredients list is grouped, it is recommended to write the list of ingredients again to the according step without their amount.

## Changes
- `src/lib/server/services/ai.service.ts` — appended the grouped-ingredients guidance to the recipe-parser system prompt. No schema or API changes needed; the existing `extractionSchema` already permits per-step instruction text.

## Validation
- `npm run check` — 0 errors
- `npm run lint` — prettier + eslint clean
- `npm run test` — 106 tests pass

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)