### PR TITLE
Harden authentication: login rate limiting, constant-time compare, JWT pinning

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -12,6 +12,7 @@ declare global {
 				| 'PERMISSION_DENIED'
 				| 'CONFIGURATION_ERROR'
 				| 'INVALID_CREDENTIALS'
+				| 'RATE_LIMITED'
 				| 'UNHANDLED_ERROR';
 			details?: unknown;
 		}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,10 @@
 import { JWT_SECRET } from '$env/static/private';
-import { deleteSessionTokenCookie, sessionCookieName } from '$lib/server/auth/auth';
+import {
+	deleteSessionTokenCookie,
+	SESSION_ALGORITHM,
+	SESSION_ISSUER,
+	sessionCookieName
+} from '$lib/server/auth/auth';
 import type { ROLE } from '$lib/server/auth/permissions';
 import { redirect, type Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
@@ -16,7 +21,10 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 
 	if (sessionToken) {
 		try {
-			const token = jwt.verify(sessionToken, JWT_SECRET);
+			const token = jwt.verify(sessionToken, JWT_SECRET, {
+				algorithms: [SESSION_ALGORITHM],
+				issuer: SESSION_ISSUER
+			});
 			event.locals.roles = (token as { roles: ROLE[] }).roles;
 		} catch {
 			console.warn('Session token is invalid, deleting cookie and redirecting to /auth');

--- a/src/lib/api/auth.remote.ts
+++ b/src/lib/api/auth.remote.ts
@@ -3,9 +3,11 @@ import { AUTH_PASSWORD } from '$env/static/private';
 import {
 	deleteSessionTokenCookie,
 	generateSessionToken,
-	setSessionTokenCookie
+	setSessionTokenCookie,
+	verifyPassword
 } from '$lib/server/auth/auth';
 import { getRoles } from '$lib/server/auth/permissions';
+import { checkRateLimit, recordFailedAttempt, resetAttempts } from '$lib/server/auth/rateLimiter';
 import { error, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 
@@ -26,11 +28,25 @@ export const login = form(
 		returnTo: z.string().optional()
 	}),
 	async ({ password, returnTo }) => {
-		if (password !== AUTH_PASSWORD) {
+		const event = getRequestEvent();
+		const clientKey = event.getClientAddress();
+
+		const { limited, retryAfterMs } = checkRateLimit(clientKey);
+		if (limited) {
+			const retryAfterMinutes = Math.ceil(retryAfterMs / 60_000);
+			error(429, {
+				message: `Too many login attempts. Try again in ${retryAfterMinutes} minute${retryAfterMinutes === 1 ? '' : 's'}.`,
+				code: 'RATE_LIMITED'
+			});
+		}
+
+		if (!verifyPassword(password, AUTH_PASSWORD)) {
+			recordFailedAttempt(clientKey);
 			error(401, { message: 'Invalid password', code: 'INVALID_CREDENTIALS' });
 		}
 
-		const event = getRequestEvent();
+		resetAttempts(clientKey);
+
 		const { token, expires } = generateSessionToken();
 		setSessionTokenCookie(event, token, expires);
 

--- a/src/lib/server/auth/auth.ts
+++ b/src/lib/server/auth/auth.ts
@@ -1,12 +1,28 @@
 import { JWT_SECRET } from '$env/static/private';
 import { type RequestEvent } from '@sveltejs/kit';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import jwt from 'jsonwebtoken';
 import { ADMIN_ROLE } from './permissions';
 
 export const sessionCookieName = 'auth-session';
 
+// Shared between signing and verification so the two never drift apart.
+export const SESSION_ISSUER = 'rezeptly';
+export const SESSION_ALGORITHM = 'HS256';
+
 const SESSION_DURATION_IN_S = 60 * 60 * 24; // 1 day in seconds
 const SESSION_TOKEN_LIFETIME_IN_DAYS = 7;
+
+/**
+ * Constant-time comparison of two secrets. Both inputs are hashed to fixed-length
+ * buffers first so the comparison never throws on length mismatch and its duration
+ * does not leak the secret's length.
+ */
+export function verifyPassword(candidate: string, expected: string): boolean {
+	const candidateHash = createHash('sha256').update(candidate).digest();
+	const expectedHash = createHash('sha256').update(expected).digest();
+	return timingSafeEqual(candidateHash, expectedHash);
+}
 
 export function setSessionTokenCookie(event: RequestEvent, token: string, expiresAt: Date) {
 	event.cookies.set(sessionCookieName, token, {
@@ -32,7 +48,8 @@ export function generateSessionToken(): { token: string; expires: Date } {
 
 	const token = jwt.sign({ app: 'rezeptly', roles: [ADMIN_ROLE] }, JWT_SECRET, {
 		expiresIn: `${SESSION_DURATION_IN_S * SESSION_TOKEN_LIFETIME_IN_DAYS}s`,
-		issuer: 'rezeptly'
+		issuer: SESSION_ISSUER,
+		algorithm: SESSION_ALGORITHM
 	});
 
 	return { token, expires };

--- a/src/lib/server/auth/rateLimiter.spec.ts
+++ b/src/lib/server/auth/rateLimiter.spec.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+	checkRateLimit,
+	LOGIN_MAX_ATTEMPTS,
+	LOGIN_WINDOW_MS,
+	recordFailedAttempt,
+	resetAttempts
+} from './rateLimiter';
+
+describe('rateLimiter', () => {
+	const key = 'test-ip';
+	const now = 1_000_000;
+
+	beforeEach(() => {
+		resetAttempts(key);
+	});
+
+	it('does not limit an unseen key', () => {
+		expect(checkRateLimit(key, now)).toEqual({ limited: false, retryAfterMs: 0 });
+	});
+
+	it('does not limit while attempts stay below the threshold', () => {
+		for (let i = 0; i < LOGIN_MAX_ATTEMPTS - 1; i++) {
+			recordFailedAttempt(key, now);
+		}
+		expect(checkRateLimit(key, now).limited).toBe(false);
+	});
+
+	it('limits once the threshold is reached', () => {
+		for (let i = 0; i < LOGIN_MAX_ATTEMPTS; i++) {
+			recordFailedAttempt(key, now);
+		}
+		const result = checkRateLimit(key, now);
+		expect(result.limited).toBe(true);
+		expect(result.retryAfterMs).toBeGreaterThan(0);
+		expect(result.retryAfterMs).toBeLessThanOrEqual(LOGIN_WINDOW_MS);
+	});
+
+	it('clears the limit once the window has elapsed', () => {
+		for (let i = 0; i < LOGIN_MAX_ATTEMPTS; i++) {
+			recordFailedAttempt(key, now);
+		}
+		expect(checkRateLimit(key, now).limited).toBe(true);
+		expect(checkRateLimit(key, now + LOGIN_WINDOW_MS + 1).limited).toBe(false);
+	});
+
+	it('resetAttempts immediately unblocks a limited key', () => {
+		for (let i = 0; i < LOGIN_MAX_ATTEMPTS; i++) {
+			recordFailedAttempt(key, now);
+		}
+		expect(checkRateLimit(key, now).limited).toBe(true);
+
+		resetAttempts(key);
+		expect(checkRateLimit(key, now).limited).toBe(false);
+	});
+
+	it('starts a fresh window after the previous one expires', () => {
+		for (let i = 0; i < LOGIN_MAX_ATTEMPTS; i++) {
+			recordFailedAttempt(key, now);
+		}
+		// A new failed attempt after expiry opens a new window rather than staying limited.
+		const later = now + LOGIN_WINDOW_MS + 1;
+		recordFailedAttempt(key, later);
+		expect(checkRateLimit(key, later).limited).toBe(false);
+	});
+
+	it('keeps keys independent', () => {
+		for (let i = 0; i < LOGIN_MAX_ATTEMPTS; i++) {
+			recordFailedAttempt('other-ip', now);
+		}
+		expect(checkRateLimit('other-ip', now).limited).toBe(true);
+		expect(checkRateLimit(key, now).limited).toBe(false);
+		resetAttempts('other-ip');
+	});
+});

--- a/src/lib/server/auth/rateLimiter.ts
+++ b/src/lib/server/auth/rateLimiter.ts
@@ -1,0 +1,71 @@
+/**
+ * Simple in-memory fixed-window rate limiter used to throttle login attempts.
+ *
+ * NOTE: state lives in the memory of a single server instance. In a serverless or
+ * multi-instance deployment (e.g. Vercel) this is a best-effort baseline rather than
+ * a hard guarantee — an attacker spread across instances gets a separate budget per
+ * instance. It still meaningfully raises the cost of brute-forcing the shared
+ * password. For strong guarantees, back this with a shared store (Redis / Postgres).
+ */
+
+export const LOGIN_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+export const LOGIN_MAX_ATTEMPTS = 5;
+
+// Guards against unbounded memory growth from many distinct keys (e.g. spoofed IPs).
+const MAX_TRACKED_KEYS = 10_000;
+
+type Attempt = { count: number; expiresAt: number };
+
+const attempts = new Map<string, Attempt>();
+
+function prune(now: number): void {
+	for (const [key, attempt] of attempts) {
+		if (attempt.expiresAt <= now) {
+			attempts.delete(key);
+		}
+	}
+}
+
+export type RateLimitResult = { limited: boolean; retryAfterMs: number };
+
+/**
+ * Returns whether the given key is currently rate limited without recording an attempt.
+ */
+export function checkRateLimit(key: string, now: number = Date.now()): RateLimitResult {
+	const attempt = attempts.get(key);
+
+	if (!attempt || attempt.expiresAt <= now) {
+		return { limited: false, retryAfterMs: 0 };
+	}
+
+	if (attempt.count >= LOGIN_MAX_ATTEMPTS) {
+		return { limited: true, retryAfterMs: attempt.expiresAt - now };
+	}
+
+	return { limited: false, retryAfterMs: 0 };
+}
+
+/**
+ * Records a failed attempt for the given key, opening a new window if none is active.
+ */
+export function recordFailedAttempt(key: string, now: number = Date.now()): void {
+	if (attempts.size >= MAX_TRACKED_KEYS) {
+		prune(now);
+	}
+
+	const attempt = attempts.get(key);
+
+	if (!attempt || attempt.expiresAt <= now) {
+		attempts.set(key, { count: 1, expiresAt: now + LOGIN_WINDOW_MS });
+		return;
+	}
+
+	attempt.count += 1;
+}
+
+/**
+ * Clears any tracked attempts for the given key (call after a successful login).
+ */
+export function resetAttempts(key: string): void {
+	attempts.delete(key);
+}

--- a/src/lib/server/auth/rateLimiter.ts
+++ b/src/lib/server/auth/rateLimiter.ts
@@ -18,6 +18,11 @@ type Attempt = { count: number; expiresAt: number };
 
 const attempts = new Map<string, Attempt>();
 
+/**
+ * Drops keys whose window has elapsed, capping map growth.
+ *
+ * @param now - Current time in epoch ms.
+ */
 function prune(now: number): void {
 	for (const [key, attempt] of attempts) {
 		if (attempt.expiresAt <= now) {
@@ -29,7 +34,11 @@ function prune(now: number): void {
 export type RateLimitResult = { limited: boolean; retryAfterMs: number };
 
 /**
- * Returns whether the given key is currently rate limited without recording an attempt.
+ * Reports whether a key is over its budget, without mutating state.
+ *
+ * @param key - Caller identifier (e.g. client IP).
+ * @param now - Current time in epoch ms; defaults to `Date.now()`.
+ * @returns `limited` plus `retryAfterMs` of lockout remaining (0 when not limited).
  */
 export function checkRateLimit(key: string, now: number = Date.now()): RateLimitResult {
 	const attempt = attempts.get(key);
@@ -46,7 +55,10 @@ export function checkRateLimit(key: string, now: number = Date.now()): RateLimit
 }
 
 /**
- * Records a failed attempt for the given key, opening a new window if none is active.
+ * Records one failed attempt, opening a new window if none is active.
+ *
+ * @param key - Caller identifier (e.g. client IP).
+ * @param now - Current time in epoch ms; defaults to `Date.now()`.
  */
 export function recordFailedAttempt(key: string, now: number = Date.now()): void {
 	if (attempts.size >= MAX_TRACKED_KEYS) {
@@ -64,7 +76,9 @@ export function recordFailedAttempt(key: string, now: number = Date.now()): void
 }
 
 /**
- * Clears any tracked attempts for the given key (call after a successful login).
+ * Clears a key's attempts, restoring its full budget (call on successful login).
+ *
+ * @param key - Caller identifier (e.g. client IP).
  */
 export function resetAttempts(key: string): void {
 	attempts.delete(key);


### PR DESCRIPTION
## Summary

Addresses three authentication findings from a security review of the login flow / auth-state handling. The underlying design (single shared-password → HS256 JWT → server-side `userCanWrite()` guards on every mutation) was already sound; these changes harden the parts that protect the shared password and validate the token.

## Changes

### 1. Login rate limiting (Medium)
A single password is the entire security boundary and login had no throttling, allowing unlimited guesses.
- New `src/lib/server/auth/rateLimiter.ts`: per-IP fixed-window limiter (5 attempts / 15 min) with map pruning to cap memory.
- `login` now checks the limit before comparing, records failures, resets on success, and returns `429` with a "try again in N minutes" message (surfaced by the existing auth-page error handling).
- **Caveat, by design:** state is per server instance — a best-effort baseline on serverless (Vercel), documented in the module. A shared store (Redis/Postgres) would be needed for a hard guarantee.

### 2. Constant-time password comparison (Low→Medium)
`password !== AUTH_PASSWORD` short-circuited, leaking a timing side channel.
- New `verifyPassword()` hashes both inputs (SHA-256) and compares via `crypto.timingSafeEqual`.

### 3. JWT verification hardening (Low)
`jwt.verify()` pinned neither the algorithm nor the issuer.
- Verification now passes `{ algorithms: ['HS256'], issuer: 'rezeptly' }`, with shared `SESSION_ISSUER` / `SESSION_ALGORITHM` constants used by both sign and verify. Backward-compatible — existing cookies were already signed with that issuer/algorithm.

Also added `RATE_LIMITED` to the `App.Error` code union.

## Testing
- `npm run check` — 0 errors
- `npm test` — 113 passed, including 7 new rate-limiter tests (`rateLimiter.spec.ts`)
- `npm run lint` — clean

## Out of scope
Finding #6 (no max upload size) was filed separately as #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)