### PR TITLE
feat(recipes): add draft mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Commands and Scripts are defined in the `package.json` file. Prefer scripts over
 - **Database**: Use Drizzle ORM with transactions for multi-step operations. Use `pnpm db:push` for rapid prototyping and `pnpm db:generate` for production migrations. Migration files must be generated. Hand-edits require approval.
 - **Services**: Keep business logic in `$lib/server/services/`, database queries in services not routes, and blob/file side effects in services too.
 - **Architecture**: Keep routes and remote functions thin; put validation at the boundary and refresh remote queries after mutations.
+- **Cron jobs**: Background jobs live in `src/routes/api/cron/` and are scheduled in `vercel.json`.
 - **Comments**: Minimal comments; code should be self-documenting
 
 ## Documentation

--- a/drizzle/0012_RecipePublishedAt.sql
+++ b/drizzle/0012_RecipePublishedAt.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "recipes" ADD COLUMN "published_at" timestamp;--> statement-breakpoint
+UPDATE "recipes" SET "published_at" = COALESCE("created_at", now());

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,379 @@
+{
+  "id": "92a0c2b5-d028-4d9f-bd0a-3fd7e0d67a6e",
+  "prevId": "c68442d1-a277-435a-a1b8-d075e359e1db",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ingredients": {
+      "name": "ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingredients_recipe_id_idx": {
+          "name": "ingredients_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingredients_recipe_id_recipes_id_fk": {
+          "name": "ingredients_recipe_id_recipes_id_fk",
+          "tableFrom": "ingredients",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instructions": {
+      "name": "instructions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "instructions_recipe_id_idx": {
+          "name": "instructions_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instructions_recipe_id_recipes_id_fk": {
+          "name": "instructions_recipe_id_recipes_id_fk",
+          "tableFrom": "instructions",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portions": {
+          "name": "portions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipes_slug_unique": {
+          "name": "recipes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipes_to_tags": {
+      "name": "recipes_to_tags",
+      "schema": "",
+      "columns": {
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "recipes_to_tags_tag_id_idx": {
+          "name": "recipes_to_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipes_to_tags_recipe_id_recipes_id_fk": {
+          "name": "recipes_to_tags_recipe_id_recipes_id_fk",
+          "tableFrom": "recipes_to_tags",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipes_to_tags_tag_id_tags_id_fk": {
+          "name": "recipes_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "recipes_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "recipes_to_tags_recipe_id_tag_id_pk": {
+          "name": "recipes_to_tags_recipe_id_tag_id_pk",
+          "columns": [
+            "recipe_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "tag_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_slug_idx": {
+          "name": "tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_slug_category_unique": {
+          "name": "tags_slug_category_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug",
+            "category"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.tag_category": {
+      "name": "tag_category",
+      "schema": "public",
+      "values": [
+        "type",
+        "cuisine",
+        "nutrition",
+        "diet"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1778934417842,
       "tag": "0011_RecipePortions",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1785490251306,
+      "tag": "0012_RecipePublishedAt",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.css
+++ b/src/app.css
@@ -21,6 +21,8 @@
 	--accent: oklch(0.967 0.001 286.375);
 	--accent-foreground: oklch(0.21 0.006 285.885);
 	--destructive: oklch(0.577 0.245 27.325);
+	--draft: oklch(0.558 0.288 302.321);
+	--draft-foreground: oklch(0.985 0 0);
 	--border: oklch(0.92 0.004 286.32);
 	--input: oklch(0.92 0.004 286.32);
 	--ring: oklch(0.705 0.015 286.067);
@@ -55,6 +57,8 @@
 	--accent: oklch(0.274 0.006 286.033);
 	--accent-foreground: oklch(0.985 0 0);
 	--destructive: oklch(0.704 0.191 22.216);
+	--draft: oklch(0.627 0.265 303.9);
+	--draft-foreground: oklch(0.985 0 0);
 	--border: oklch(1 0 0 / 10%);
 	--input: oklch(1 0 0 / 15%);
 	--ring: oklch(0.552 0.016 285.938);
@@ -93,6 +97,8 @@
 	--color-accent: var(--accent);
 	--color-accent-foreground: var(--accent-foreground);
 	--color-destructive: var(--destructive);
+	--color-draft: var(--draft);
+	--color-draft-foreground: var(--draft-foreground);
 	--color-border: var(--border);
 	--color-input: var(--input);
 	--color-ring: var(--ring);

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,7 +10,7 @@ import { redirect, type Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import jwt from 'jsonwebtoken';
 
-const protectedRoutes = ['/create'];
+const protectedRoutes = ['/create', '/drafts'];
 
 const handleAuth: Handle = async ({ event, resolve }) => {
 	const sessionToken = event.cookies.get(sessionCookieName);

--- a/src/lib/api/recipes.remote.ts
+++ b/src/lib/api/recipes.remote.ts
@@ -29,10 +29,6 @@ export const getAvailableTags = query(async () => {
 	return await tagService.getAllActiveTags();
 });
 
-export const getRecipes = query(async () => {
-	return await recipeService.getRecipes({ includeDrafts: userCanWrite() });
-});
-
 export const getRecipeBySlug = query(z.string(), async (slug) => {
 	const recipe = await recipeService.getRecipeBySlug(slug, { includeDrafts: userCanWrite() });
 	return recipe;

--- a/src/lib/api/recipes.remote.ts
+++ b/src/lib/api/recipes.remote.ts
@@ -1,5 +1,5 @@
 import { command, form, query } from '$app/server';
-import { userCanWrite } from '$lib/server/auth/permissions';
+import { guardedQuery, userCanWrite } from '$lib/server/auth/permissions';
 import * as aiService from '$lib/server/services/ai.service';
 import * as imageService from '$lib/server/services/image.service';
 import * as ingredientService from '$lib/server/services/ingredient.service';
@@ -21,16 +21,20 @@ export const getRecipesMetadata = query(async () => {
 	return await recipeService.getRecipesMetadata();
 });
 
+export const getDraftRecipesMetadata = guardedQuery(async () => {
+	return await recipeService.getRecipesMetadata(undefined, undefined, { onlyDrafts: true });
+});
+
 export const getAvailableTags = query(async () => {
 	return await tagService.getAllActiveTags();
 });
 
 export const getRecipes = query(async () => {
-	return await recipeService.getRecipes();
+	return await recipeService.getRecipes({ includeDrafts: userCanWrite() });
 });
 
 export const getRecipeBySlug = query(z.string(), async (slug) => {
-	const recipe = await recipeService.getRecipeBySlug(slug);
+	const recipe = await recipeService.getRecipeBySlug(slug, { includeDrafts: userCanWrite() });
 	return recipe;
 });
 
@@ -69,7 +73,7 @@ export const addIngredient = form(
 			throwNewPermissionError();
 		}
 
-		const recipe = await recipeService.getRecipeById(recipeId);
+		const recipe = await recipeService.getRecipeById(recipeId, { includeDrafts: true });
 		await ingredientService.createIngredient({ name: name.trim(), recipeId });
 
 		await getRecipeBySlug(recipe.slug).refresh();
@@ -86,7 +90,7 @@ export const removeIngredient = command(
 			throwNewPermissionError();
 		}
 
-		const recipe = await recipeService.getRecipeById(recipeId);
+		const recipe = await recipeService.getRecipeById(recipeId, { includeDrafts: true });
 		await ingredientService.deleteIngredient(ingrId);
 		await getRecipeBySlug(recipe.slug).refresh();
 	}
@@ -113,7 +117,7 @@ export const editIngredient = form(
 			throwNewPermissionError();
 		}
 
-		const recipe = await recipeService.getRecipeById(recipeId);
+		const recipe = await recipeService.getRecipeById(recipeId, { includeDrafts: true });
 		await ingredientService.updateIngredient(ingrId, name.trim());
 		await getRecipeBySlug(recipe.slug).refresh();
 	}
@@ -158,7 +162,7 @@ export const updateRecipeDetails = form(
 			diet: tagDiet
 		});
 
-		const recipe = await recipeService.getRecipeById(recipeId);
+		const recipe = await recipeService.getRecipeById(recipeId, { includeDrafts: true });
 		const oldSlug = recipe.slug;
 
 		const result = await recipeService.updateRecipe(recipeId, {
@@ -249,7 +253,7 @@ export const updateInstructions = form(
 			throwNewPermissionError();
 		}
 
-		const recipe = await recipeService.getRecipeById(recipeId);
+		const recipe = await recipeService.getRecipeById(recipeId, { includeDrafts: true });
 
 		await instructionService.upsertInstructionsForRecipe(
 			recipeId,
@@ -300,9 +304,27 @@ export const updateRecipePortions = command(
 			throwNewPermissionError();
 		}
 
-		const recipe = await recipeService.getRecipeById(recipeId);
+		const recipe = await recipeService.getRecipeById(recipeId, { includeDrafts: true });
 		await recipeService.updateRecipe(recipeId, { portions });
 		await getRecipeBySlug(recipe.slug).refresh();
+	}
+);
+
+export const setRecipePublished = command(
+	z.object({
+		recipeId: z.number(),
+		published: z.boolean()
+	}),
+	async ({ recipeId, published }) => {
+		if (!userCanWrite()) {
+			throwNewPermissionError();
+		}
+
+		const recipe = await recipeService.setRecipePublished(recipeId, published);
+
+		await getRecipeBySlug(recipe.slug).refresh();
+		await getRecipesMetadata().refresh();
+		await getDraftRecipesMetadata().refresh();
 	}
 );
 
@@ -311,7 +333,7 @@ export const deleteRecipeImage = command(z.number(), async (recipeId) => {
 		throwNewPermissionError();
 	}
 
-	const recipe = await recipeService.getRecipeById(recipeId);
+	const recipe = await recipeService.getRecipeById(recipeId, { includeDrafts: true });
 
 	if (!recipe.imageUrl) {
 		error(400, { message: 'Recipe does not have an image to delete', code: 'VALIDATION_ERROR' });

--- a/src/lib/components/recipes/CardComponent.svelte
+++ b/src/lib/components/recipes/CardComponent.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ImagePlaceholderComponent from '$lib/components/common/ImagePlaceholderComponent.svelte';
+	import DraftBadgeComponent from '$lib/components/recipes/DraftBadgeComponent.svelte';
 	import TagsContainerComponent from '$lib/components/recipes/TagsContainerComponent.svelte';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card/';
@@ -22,7 +23,8 @@
 
 <Card.Root class="group h-full gap-0 overflow-hidden px-0 pt-0">
 	<Card.Header class="p-0">
-		<div class="h-48 overflow-hidden">
+		<div class="relative h-48 overflow-hidden">
+			<DraftBadgeComponent publishedAt={recipe.publishedAt} class="absolute top-2 left-2 z-10" />
 			{#if recipe.imageUrl && !isImageBroken}
 				<img
 					src={recipe.imageUrl}

--- a/src/lib/components/recipes/DraftBadgeComponent.svelte
+++ b/src/lib/components/recipes/DraftBadgeComponent.svelte
@@ -6,6 +6,7 @@
 </script>
 
 {#if publishedAt === null}
-	<Badge class={cn('border-transparent bg-purple-600 text-white shadow-sm', className)}>Draft</Badge
+	<Badge class={cn('bg-draft text-draft-foreground border-transparent shadow-sm', className)}
+		>Draft</Badge
 	>
 {/if}

--- a/src/lib/components/recipes/DraftBadgeComponent.svelte
+++ b/src/lib/components/recipes/DraftBadgeComponent.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { Badge } from '$lib/components/ui/badge';
+	import { cn } from '$lib/utils';
+
+	const { publishedAt, class: className }: { publishedAt: Date | null; class?: string } = $props();
+</script>
+
+{#if publishedAt === null}
+	<Badge class={cn('border-transparent bg-purple-600 text-white shadow-sm', className)}>Draft</Badge
+	>
+{/if}

--- a/src/lib/components/recipes/DraftBadgeComponent.svelte.spec.ts
+++ b/src/lib/components/recipes/DraftBadgeComponent.svelte.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+import DraftBadgeComponent from './DraftBadgeComponent.svelte';
+
+describe('DraftBadgeComponent.svelte', () => {
+	it('should render the badge for a draft recipe', async () => {
+		render(DraftBadgeComponent, { publishedAt: null });
+		await expect.element(page.getByText('Draft')).toBeInTheDocument();
+	});
+
+	it('should render nothing for a released recipe', async () => {
+		render(DraftBadgeComponent, { publishedAt: new Date('2026-01-01') });
+		await expect.element(page.getByText('Draft')).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/components/recipes/PublishButtonComponent.svelte
+++ b/src/lib/components/recipes/PublishButtonComponent.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import { setRecipePublished } from '$lib/api/recipes.remote';
+	import LoadingComponent from '$lib/components/common/LoadingComponent.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { PermissionsStore } from '$lib/store/roles.svelte';
+	import EyeOffIcon from '@lucide/svelte/icons/eye-off';
+	import SendIcon from '@lucide/svelte/icons/send';
+
+	const { recipeId, publishedAt }: { recipeId: number; publishedAt: Date | null } = $props();
+
+	const isDraft = $derived(publishedAt === null);
+</script>
+
+{#if PermissionsStore.canEdit}
+	<Button
+		variant={isDraft ? 'default' : 'outline'}
+		title={isDraft ? 'Publish this recipe' : 'Unpublish this recipe'}
+		disabled={!!setRecipePublished.pending}
+		onclick={async () => await setRecipePublished({ recipeId, published: isDraft })}
+	>
+		{#if !!setRecipePublished.pending}
+			<LoadingComponent class="size-4" />
+		{:else if isDraft}
+			<SendIcon />
+		{:else}
+			<EyeOffIcon />
+		{/if}
+		{isDraft ? 'Publish' : 'Unpublish'}
+	</Button>
+{/if}

--- a/src/lib/components/recipes/PublishButtonComponent.svelte
+++ b/src/lib/components/recipes/PublishButtonComponent.svelte
@@ -14,6 +14,9 @@
 {#if PermissionsStore.canEdit}
 	<Button
 		variant={isDraft ? 'default' : 'outline'}
+		class={isDraft
+			? 'bg-draft text-draft-foreground hover:bg-draft/90'
+			: 'border-draft/30 text-draft hover:bg-draft/10 hover:text-draft'}
 		title={isDraft ? 'Publish this recipe' : 'Unpublish this recipe'}
 		disabled={!!setRecipePublished.pending}
 		onclick={async () => await setRecipePublished({ recipeId, published: isDraft })}

--- a/src/lib/components/recipes/PublishButtonComponent.svelte.spec.ts
+++ b/src/lib/components/recipes/PublishButtonComponent.svelte.spec.ts
@@ -1,0 +1,34 @@
+import { PermissionsStore } from '$lib/store/roles.svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+import PublishButtonComponent from './PublishButtonComponent.svelte';
+
+describe('PublishButtonComponent.svelte', () => {
+	afterEach(() => {
+		PermissionsStore.resetRoles();
+	});
+
+	describe('with write permission', () => {
+		beforeEach(() => {
+			PermissionsStore.roles = ['admin'];
+		});
+
+		it('should offer to publish a draft recipe', async () => {
+			render(PublishButtonComponent, { recipeId: 1, publishedAt: null });
+			await expect.element(page.getByRole('button', { name: 'Publish' })).toBeInTheDocument();
+		});
+
+		it('should offer to unpublish a released recipe', async () => {
+			render(PublishButtonComponent, { recipeId: 1, publishedAt: new Date('2026-01-01') });
+			await expect.element(page.getByRole('button', { name: 'Unpublish' })).toBeInTheDocument();
+		});
+	});
+
+	describe('without write permission', () => {
+		it('should render nothing', async () => {
+			render(PublishButtonComponent, { recipeId: 1, publishedAt: null });
+			await expect.element(page.getByRole('button')).not.toBeInTheDocument();
+		});
+	});
+});

--- a/src/lib/components/recipes/RecipeDetailsComponent.svelte
+++ b/src/lib/components/recipes/RecipeDetailsComponent.svelte
@@ -9,6 +9,8 @@
 	import StarIcon from '@lucide/svelte/icons/star';
 	import UsersIcon from '@lucide/svelte/icons/users';
 	import DeleteRecipeConfirmationModal from './DeleteRecipeConfirmationModal.svelte';
+	import DraftBadgeComponent from './DraftBadgeComponent.svelte';
+	import PublishButtonComponent from './PublishButtonComponent.svelte';
 	import RecipeDetailsFormComponent from './RecipeDetailsFormComponent.svelte';
 	import TagsContainer from './TagsContainerComponent.svelte';
 
@@ -39,12 +41,16 @@
 	{#if editDetails}
 		<RecipeDetailsFormComponent {recipe} onSave={closeForm} onCancel={closeForm} />
 	{:else}
-		<h2
-			style:view-transition-name="recipe-title-{recipe.id}"
-			class="mt-2 text-3xl font-extrabold tracking-tight text-shadow-xs sm:text-4xl"
-		>
-			{recipe.name}
-		</h2>
+		<div class="mt-2 flex flex-row flex-wrap items-center gap-3">
+			<h2
+				style:view-transition-name="recipe-title-{recipe.id}"
+				class="text-3xl font-extrabold tracking-tight text-shadow-xs sm:text-4xl"
+			>
+				{recipe.name}
+			</h2>
+			<DraftBadgeComponent publishedAt={recipe.publishedAt} />
+			<PublishButtonComponent recipeId={recipe.id} publishedAt={recipe.publishedAt} />
+		</div>
 
 		{#if recipe.description}
 			<p class="mt-3 text-sm text-zinc-500 max-w-3xl">

--- a/src/lib/components/recipes/RecipeDetailsComponent.svelte
+++ b/src/lib/components/recipes/RecipeDetailsComponent.svelte
@@ -49,7 +49,9 @@
 				{recipe.name}
 			</h2>
 			<DraftBadgeComponent publishedAt={recipe.publishedAt} />
-			<PublishButtonComponent recipeId={recipe.id} publishedAt={recipe.publishedAt} />
+			<div class="ml-auto">
+				<PublishButtonComponent recipeId={recipe.id} publishedAt={recipe.publishedAt} />
+			</div>
 		</div>
 
 		{#if recipe.description}

--- a/src/lib/components/recipes/RecipeListComponent.svelte
+++ b/src/lib/components/recipes/RecipeListComponent.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import CardComponent from '$lib/components/recipes/CardComponent.svelte';
+	import FilterComponent from '$lib/components/recipes/FilterComponent.svelte';
+	import type { RecipeMetadata } from '$lib/server/types';
+	import { TAG_CATEGORIES } from '$lib/shared/tags';
+	import { AvailableTagsStore } from '$lib/store/available-tags.svelte';
+	import { favoritesStore } from '$lib/store/favorites';
+	import { Debounced } from 'runed';
+	import { useSearchParams } from 'runed/kit';
+	import z from 'zod';
+
+	const { recipes }: { recipes: RecipeMetadata[] } = $props();
+
+	const favorites = favoritesStore;
+
+	const searchParams = useSearchParams(
+		z.object({
+			filterFavorites: z.boolean().default(false),
+			searchTerm: z.string().optional().default(''),
+			type: z.array(z.string()).default([]),
+			cuisine: z.array(z.string()).default([]),
+			nutrition: z.array(z.string()).default([]),
+			diet: z.array(z.string()).default([])
+		})
+	);
+
+	const debouncedSearchTerm = new Debounced(() => searchParams.searchTerm, 250);
+
+	const filteredRecipes = $derived(
+		(recipes ?? []).filter((r) => {
+			const matchesSearchTerm =
+				!searchParams.searchTerm ||
+				r.name.toLowerCase().includes(debouncedSearchTerm.current.toLowerCase());
+
+			const matchesTagFilter = TAG_CATEGORIES.every((category) => {
+				const selected = searchParams[category] as string[];
+				if (!selected || selected.length === 0) return true;
+				return r.tags.some((t) => t.category === category && selected.includes(t.slug));
+			});
+
+			const matchesFavoritesFilter =
+				!searchParams.filterFavorites || favorites.current.includes(r.id);
+
+			return matchesSearchTerm && matchesTagFilter && matchesFavoritesFilter;
+		})
+	);
+</script>
+
+<FilterComponent
+	bind:searchTerm={searchParams.searchTerm}
+	bind:filterFavorites={searchParams.filterFavorites}
+	bind:type={searchParams.type}
+	bind:cuisine={searchParams.cuisine}
+	bind:nutrition={searchParams.nutrition}
+	bind:diet={searchParams.diet}
+	availableTags={AvailableTagsStore.tags}
+/>
+
+<div class="card-container my-4 grid gap-4">
+	{#each filteredRecipes as recipe (recipe.id)}
+		<a
+			href="/{recipe.slug}"
+			class="block transition-all duration-200 hover:shadow-xl active:scale-[0.98] rounded-xl"
+		>
+			<CardComponent {recipe} />
+		</a>
+	{/each}
+</div>
+
+<style>
+	.card-container {
+		grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+	}
+</style>

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -21,7 +21,8 @@ export const recipes = pgTable('recipes', {
 	imageUrl: text('image_url'),
 	durationMinutes: integer('duration_minutes'),
 	portions: integer('portions'),
-	createdAt: timestamp('created_at').defaultNow()
+	createdAt: timestamp('created_at').defaultNow(),
+	publishedAt: timestamp('published_at')
 });
 
 export const recipesRelations = relations(recipes, ({ many }) => ({

--- a/src/lib/server/services/recipe.service.ts
+++ b/src/lib/server/services/recipe.service.ts
@@ -87,20 +87,6 @@ export const countRecipes = async (
 	return totals?.value ?? 0;
 };
 
-export const getRecipes = async (options?: ReadOptions): Promise<RecipeWithDetails[]> => {
-	const result = await db.query.recipes.findMany({
-		where: recipeVisibility(options),
-		with: {
-			ingredients: true,
-			instructions: { orderBy: (i, { asc }) => [asc(i.stepOrder)] },
-			tags: { with: { tag: true } }
-		},
-		orderBy: (recipes, { desc }) => [desc(recipes.createdAt)]
-	});
-
-	return result.map(flattenTags);
-};
-
 export const getRecipeById = async (
 	id: number,
 	options?: ReadOptions

--- a/src/lib/server/services/recipe.service.ts
+++ b/src/lib/server/services/recipe.service.ts
@@ -15,6 +15,9 @@ import type {
 import { deleteImage } from './image.service';
 import { upsertTags } from './tag.service';
 import { generateSlug } from './util/generate-slug';
+import { recipeVisibility, type ReadOptions } from './util/recipe-visibility';
+
+export type { ReadOptions };
 
 const flattenTags = <T extends { tags: { tag: Tag }[] }>(row: T) => ({
 	...row,
@@ -29,8 +32,13 @@ export type RecipeFilter = {
 /** Escapes ILIKE wildcards so a user-supplied term matches literally. */
 const escapeLike = (term: string) => term.replace(/[\\%_]/g, '\\$&');
 
-const buildRecipeWhere = (filter?: RecipeFilter): SQL | undefined => {
+const buildRecipeWhere = (filter?: RecipeFilter, options?: ReadOptions): SQL | undefined => {
 	const conditions: SQL[] = [];
+
+	const visibility = recipeVisibility(options);
+	if (visibility) {
+		conditions.push(visibility);
+	}
 
 	const search = filter?.search?.trim();
 	if (search) {
@@ -55,10 +63,11 @@ const buildRecipeWhere = (filter?: RecipeFilter): SQL | undefined => {
 
 export const getRecipesMetadata = async (
 	filter?: RecipeFilter,
-	page?: { limit: number; offset: number }
+	page?: { limit: number; offset: number },
+	options?: ReadOptions
 ): Promise<RecipeMetadata[]> => {
 	const result = await db.query.recipes.findMany({
-		where: buildRecipeWhere(filter),
+		where: buildRecipeWhere(filter, options),
 		with: { tags: { with: { tag: true } } },
 		orderBy: (recipes, { desc }) => [desc(recipes.createdAt)],
 		...page
@@ -67,16 +76,20 @@ export const getRecipesMetadata = async (
 	return result.map(flattenTags);
 };
 
-export const countRecipes = async (filter?: RecipeFilter): Promise<number> => {
+export const countRecipes = async (
+	filter?: RecipeFilter,
+	options?: ReadOptions
+): Promise<number> => {
 	const [totals] = await db
 		.select({ value: count() })
 		.from(recipes)
-		.where(buildRecipeWhere(filter));
+		.where(buildRecipeWhere(filter, options));
 	return totals?.value ?? 0;
 };
 
-export const getRecipes = async (): Promise<RecipeWithDetails[]> => {
+export const getRecipes = async (options?: ReadOptions): Promise<RecipeWithDetails[]> => {
 	const result = await db.query.recipes.findMany({
+		where: recipeVisibility(options),
 		with: {
 			ingredients: true,
 			instructions: { orderBy: (i, { asc }) => [asc(i.stepOrder)] },
@@ -88,9 +101,12 @@ export const getRecipes = async (): Promise<RecipeWithDetails[]> => {
 	return result.map(flattenTags);
 };
 
-export const getRecipeById = async (id: number): Promise<RecipeWithDetails> => {
+export const getRecipeById = async (
+	id: number,
+	options?: ReadOptions
+): Promise<RecipeWithDetails> => {
 	const result = await db.query.recipes.findFirst({
-		where: eq(recipes.id, id),
+		where: and(eq(recipes.id, id), recipeVisibility(options)),
 		with: {
 			ingredients: true,
 			instructions: { orderBy: (i, { asc }) => [asc(i.stepOrder)] },
@@ -105,9 +121,12 @@ export const getRecipeById = async (id: number): Promise<RecipeWithDetails> => {
 	return flattenTags(result);
 };
 
-export const getRecipeBySlug = async (slug: string): Promise<RecipeWithDetails> => {
+export const getRecipeBySlug = async (
+	slug: string,
+	options?: ReadOptions
+): Promise<RecipeWithDetails> => {
 	const result = await db.query.recipes.findFirst({
-		where: eq(recipes.slug, slug),
+		where: and(eq(recipes.slug, slug), recipeVisibility(options)),
 		with: {
 			ingredients: true,
 			instructions: { orderBy: (i, { asc }) => [asc(i.stepOrder)] },
@@ -248,9 +267,23 @@ export const updateRecipe = async (
 	return updatedRecipe;
 };
 
+export const setRecipePublished = async (id: number, published: boolean): Promise<Recipe> => {
+	const [updatedRecipe] = await db
+		.update(recipes)
+		.set({ publishedAt: published ? new Date() : null })
+		.where(eq(recipes.id, id))
+		.returning();
+
+	if (!updatedRecipe) {
+		error(404, { message: `Recipe with ID ${id} not found`, code: 'NOT_FOUND' });
+	}
+
+	return updatedRecipe;
+};
+
 export const deleteRecipe = async (id: number): Promise<void> => {
 	// Get recipe to find image URL before deletion (getRecipeById throws if not found)
-	const recipe = await getRecipeById(id);
+	const recipe = await getRecipeById(id, { includeDrafts: true });
 
 	await db.delete(recipes).where(eq(recipes.id, id));
 

--- a/src/lib/server/services/util/recipe-visibility.spec.ts
+++ b/src/lib/server/services/util/recipe-visibility.spec.ts
@@ -1,24 +1,33 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { describe, expect, it } from 'vitest';
 import { recipeVisibility } from './recipe-visibility';
 
+const dialect = new PgDialect();
+const toSql = (condition: SQL | undefined) =>
+	condition ? dialect.sqlToQuery(condition).sql : undefined;
+
+const RELEASED_ONLY = '"recipes"."published_at" is not null';
+const DRAFTS_ONLY = '"recipes"."published_at" is null';
+
 describe('recipeVisibility', () => {
-	it('should filter when no options are given', () => {
-		expect(recipeVisibility()).toBeDefined();
+	it('should hide drafts when no options are given', () => {
+		expect(toSql(recipeVisibility())).toBe(RELEASED_ONLY);
 	});
 
-	it('should filter when drafts are not included', () => {
-		expect(recipeVisibility({ includeDrafts: false })).toBeDefined();
+	it('should hide drafts when they are not included', () => {
+		expect(toSql(recipeVisibility({ includeDrafts: false }))).toBe(RELEASED_ONLY);
 	});
 
 	it('should not filter when drafts are explicitly included', () => {
-		expect(recipeVisibility({ includeDrafts: true })).toBeUndefined();
+		expect(toSql(recipeVisibility({ includeDrafts: true }))).toBeUndefined();
 	});
 
-	it('should filter when only drafts are requested', () => {
-		expect(recipeVisibility({ onlyDrafts: true })).toBeDefined();
+	it('should hide released recipes when only drafts are requested', () => {
+		expect(toSql(recipeVisibility({ onlyDrafts: true }))).toBe(DRAFTS_ONLY);
 	});
 
-	it('should keep filtering when only drafts wins over including drafts', () => {
-		expect(recipeVisibility({ onlyDrafts: true, includeDrafts: true })).toBeDefined();
+	it('should keep only drafts winning over including drafts', () => {
+		expect(toSql(recipeVisibility({ onlyDrafts: true, includeDrafts: true }))).toBe(DRAFTS_ONLY);
 	});
 });

--- a/src/lib/server/services/util/recipe-visibility.spec.ts
+++ b/src/lib/server/services/util/recipe-visibility.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { recipeVisibility } from './recipe-visibility';
+
+describe('recipeVisibility', () => {
+	it('should filter when no options are given', () => {
+		expect(recipeVisibility()).toBeDefined();
+	});
+
+	it('should filter when drafts are not included', () => {
+		expect(recipeVisibility({ includeDrafts: false })).toBeDefined();
+	});
+
+	it('should not filter when drafts are explicitly included', () => {
+		expect(recipeVisibility({ includeDrafts: true })).toBeUndefined();
+	});
+
+	it('should filter when only drafts are requested', () => {
+		expect(recipeVisibility({ onlyDrafts: true })).toBeDefined();
+	});
+
+	it('should keep filtering when only drafts wins over including drafts', () => {
+		expect(recipeVisibility({ onlyDrafts: true, includeDrafts: true })).toBeDefined();
+	});
+});

--- a/src/lib/server/services/util/recipe-visibility.ts
+++ b/src/lib/server/services/util/recipe-visibility.ts
@@ -1,0 +1,19 @@
+import { isNotNull, isNull, type SQL } from 'drizzle-orm';
+import { recipes } from '../../db/schema';
+
+export type ReadOptions = {
+	includeDrafts?: boolean;
+	onlyDrafts?: boolean;
+};
+
+/**
+ * Fail-closed visibility predicate shared by every recipe read path: a caller that passes
+ * nothing gets released recipes only, so an omission hides drafts instead of leaking them.
+ */
+export const recipeVisibility = (options?: ReadOptions): SQL | undefined => {
+	if (options?.onlyDrafts) {
+		return isNull(recipes.publishedAt);
+	}
+
+	return options?.includeDrafts ? undefined : isNotNull(recipes.publishedAt);
+};

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -6,6 +6,7 @@
 	import { Button } from '$lib/components/ui/button/';
 	import { AvailableTagsStore } from '$lib/store/available-tags.svelte.js';
 	import { PermissionsStore } from '$lib/store/roles.svelte';
+	import FileTextIcon from '@lucide/svelte/icons/file-text';
 	import LoginIcon from '@lucide/svelte/icons/log-in';
 	import LogoutIcon from '@lucide/svelte/icons/log-out';
 
@@ -31,6 +32,10 @@
 			</div>
 			<div class="flex flex-row items-center gap-3">
 				{#if PermissionsStore.canEdit}
+					<Button href="/drafts" variant="ghost">
+						<FileTextIcon />
+						Drafts
+					</Button>
 					<Button href="/create" variant="default">+ Create</Button>
 				{/if}
 				{#if PermissionsStore.isLoggedIn}

--- a/src/routes/(app)/drafts/+page.svelte
+++ b/src/routes/(app)/drafts/+page.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
-	import { getRecipesMetadata } from '$lib/api/recipes.remote';
+	import { getDraftRecipesMetadata } from '$lib/api/recipes.remote';
 	import ErrorComponent from '$lib/components/common/ErrorComponent.svelte';
 	import LoadingComponent from '$lib/components/common/LoadingComponent.svelte';
+	import BreadcrumbComponent from '$lib/components/common/navigation/BreadcrumbComponent.svelte';
 	import RecipeListComponent from '$lib/components/recipes/RecipeListComponent.svelte';
 </script>
 
 <svelte:head>
-	<title>rezeptly</title>
+	<title>rezeptly | Drafts</title>
 </svelte:head>
 
+<BreadcrumbComponent breadcrumbs={[{ name: 'Drafts', href: '/drafts' }]} />
+
 <svelte:boundary>
-	{@const recipes = await getRecipesMetadata()}
+	{@const recipes = await getDraftRecipesMetadata()}
 
 	<RecipeListComponent {recipes} />
 

--- a/src/routes/(app)/mcp/+page.svelte
+++ b/src/routes/(app)/mcp/+page.svelte
@@ -49,6 +49,10 @@
 			server. Any MCP-capable client can connect to it and read the collection. Access is read-only and
 			needs no account or API key.
 		</p>
+		<p class="text-zinc-600">
+			The tools expose released recipes only. Recipes still in draft are never returned, so the tool
+			results are exactly the public view of the collection.
+		</p>
 	</section>
 
 	<section class="flex flex-col gap-2">

--- a/src/routes/api/cron/cleanup-images/+server.ts
+++ b/src/routes/api/cron/cleanup-images/+server.ts
@@ -31,8 +31,8 @@ export const GET: RequestHandler = async ({ request }) => {
 		const { blobs } = await list({ token });
 		const blobUrls = new Set(blobs.map((b) => b.url));
 
-		// Get all image URLs from recipes using recipe service
-		const allRecipes = await getRecipesMetadata();
+		// Drafts must be included, otherwise their images count as orphaned and get deleted
+		const allRecipes = await getRecipesMetadata(undefined, undefined, { includeDrafts: true });
 		const dbImageUrls = new Set(allRecipes.map((r) => r.imageUrl).filter(Boolean) as string[]);
 
 		// Find orphaned blobs (in Vercel Blob but not in database)


### PR DESCRIPTION
Closes #183

## What

Recipes now have two states: **draft** and **released**, tracked by a single nullable `recipes.published_at` timestamp (`NULL` = draft). Drafts are invisible to anyone signed out — absent from the recipe list, absent from the MCP tools, and their URLs 404 exactly like an unknown slug.

Every newly created recipe — including one imported from a photo — starts as a draft. A **Publish** button in the recipe title row releases it; the same button unpublishes a released recipe with everything intact.

## How

- **Visibility** is enforced by one fail-closed predicate, `recipeVisibility`, shared by every recipe read path. Passing nothing yields released recipes only, so forgetting the option hides drafts rather than leaking them. The MCP tools omit the option entirely, which is what keeps drafts out of the unauthenticated endpoint.
- **`/drafts`** is a new guarded page collecting unfinished work, added to `protectedRoutes` alongside `/create` and linked in the nav behind the same permission check.
- **The main recipe list is unchanged for everyone, including admins** — it always answers "what does the public see right now?".
- A purple **Draft** badge marks drafts on the recipe page (beside the title) and on recipe cards (overlaid on the image, so a long tag list can't push it onto a second line). The purple is a new `--draft` design token in `app.css`, light and dark.
- `RecipeListComponent` was extracted so `/` and `/drafts` share one filter + grid instead of duplicating ~90 lines.

## Migration

`drizzle/0012_RecipePublishedAt.sql` is generated, then hand-edited (approved) to add a backfill so **existing recipes stay live** on deploy:

```sql
UPDATE "recipes" SET "published_at" = COALESCE("created_at", now());
```

It has not been applied to any database yet.

## Tests

`pnpm check` 0 errors · `pnpm test` 123/123 · `pnpm lint` clean.

- `recipeVisibility` unit tests (server project) — the security-relevant decision, tested directly as a pure function.
- `DraftBadgeComponent` and `PublishButtonComponent` component tests (browser project) — badge renders only for drafts; the control shows Publish/Unpublish and renders nothing without write permission.

**Known gap, accepted:** nothing proves each read function actually applies the predicate — that needs a real database, and the repo has no DB harness. Mitigation is structural: one named helper means "is every read path filtered?" is one search, and the default fails closed.

## Deviations from the issue

1. `recipeVisibility` gained a third case (`onlyDrafts`) beyond the issue's two-case shape, so `/drafts` runs a real drafts-only query instead of over-fetching and filtering in the client. Default is still fail-closed.
2. `RecipeListComponent` is new — not called for in the issue, but `/drafts` would otherwise have been a near-copy of the home page.

## Out of scope (per the issue)

Scheduled publishing · preview links · per-recipe ownership · publish completeness rules · bulk publishing · draft count badges. Tags attached only to a draft still appear in the public filter bar — deliberately accepted, tag names are not sensitive.